### PR TITLE
Correctly switch tabs

### DIFF
--- a/frontend/src/components/DropdownButton.js
+++ b/frontend/src/components/DropdownButton.js
@@ -37,7 +37,9 @@ class DropdownButton extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      consoleSelectedVal: this.props.items ? this.props.items[0] : '',
+      consoleSelectedVal: this.props.items
+        ? this.props.items[parseInt(this.props.activeTab) - 1]
+        : '',
       selectedVal: this.props.title,
       dropdownOpen: false
     }

--- a/frontend/src/components/Results.js
+++ b/frontend/src/components/Results.js
@@ -173,7 +173,7 @@ class Results extends Component {
               <br />
               <hr style={{ clear: 'both' }} />
               <div>
-                <TabContent activeTab={this.state.activeTab}>
+                <TabContent activeTab={this.props.activeTab}>
                   {this.determineConsoles(this.props.results).map((x, index) => (
                     <TabPane tabId={(index + 1).toString()}>
                       <Col>{this.buildCards(this.props.results[x])}</Col>


### PR DESCRIPTION
Somewhere in merge conflicts, changing the console in the results page wouldn't update the cards displayed accordingly - this resolves that